### PR TITLE
PHP 8.4 erforderlich machen

### DIFF
--- a/fragments/jira_knowledgebase_sync/accordion_first.php
+++ b/fragments/jira_knowledgebase_sync/accordion_first.php
@@ -23,7 +23,6 @@ if ($count_categories > 1):
 	<?php
 
         foreach ($categories as $category) {
-
             $entry = Entry::query()->where('jira_knowledgebase_sync_category_id', $category->getId())->where('jiraproject', $project_code)->where('status', 1)->orderBy('name', 'ASC')->find();
             // dump($entry);
             ?>
@@ -35,9 +34,9 @@ if ($count_categories > 1):
                     $this->setVar('category_name', $category->getName(), false);
                     // i trotz subfragment weitergeben, damit hochzählen klappt
                     $this->setVar('counter_i', $i, false);
-	    echo $this->subfragment('jira_knowledgebase_sync/accordion_first_header.php');
+        echo $this->subfragment('jira_knowledgebase_sync/accordion_first_header.php');
 
-	    ?>
+        ?>
 
 		<div id="collapseGeneral-<?= $i ?>"
 			class="accordion-collapse main-accordion collapse" aria-labelledby="headingGeneral">
@@ -53,18 +52,16 @@ if ($count_categories > 1):
 						id="generalAccordion-<?= $i ?>">
 
 						<?php
-	                foreach ($entry as $acc) {
-	                    // Zweite Accordion Ebene
-	                    $this->setVar('counter_j', $j, false);
-	                    $this->setVar('acc_name', $acc->name, false);
-	                    $this->setVar('acc_jiracontent', $acc->jiracontent, false);
+                    foreach ($entry as $acc) {
+                        // Zweite Accordion Ebene
+                        $this->setVar('counter_j', $j, false);
+                        $this->setVar('acc_name', $acc->name, false);
+                        $this->setVar('acc_jiracontent', $acc->jiracontent, false);
 
                         echo $this->subfragment('jira_knowledgebase_sync/accordion_second.php');
 
-
-
-	                    ++$j;
-	                } // end of foreach
+                        ++$j;
+                    } // end of foreach
             ?>
 
 					</div> <!-- end of generalAccordion !-->

--- a/lib/Cronjob/Sync.php
+++ b/lib/Cronjob/Sync.php
@@ -8,7 +8,6 @@ use rex_i18n;
 use Ropaweb\JiraKnowledgebaseSync\Entry;
 
 use function sprintf;
-use function strlen;
 
 use const CURLOPT_HTTPHEADER;
 use const CURLOPT_RETURNTRANSFER;
@@ -166,7 +165,7 @@ class Sync extends rex_cronjob
         // klappt lokal nicht
         $content = $this->getContent($current['content']['iframeSrc']);
         $entry->setValue('jiracontent', $content);
-        //$entry->setValue('jiracontent', $current['content']['iframeSrc']);
+        // $entry->setValue('jiracontent', $current['content']['iframeSrc']);
 
         $entry->setValue('updatedate', date('Y-m-d H:i:s'));
 

--- a/package.yml
+++ b/package.yml
@@ -7,7 +7,7 @@ supportpage: https://github.com/ropaweb/jira_knowledgebase_sync # Support-Seite,
 
 requires:                       # Abhängigkeiten definieren, z.B.
     php:
-        version: '>8.1,<9'
+        version: '>=8.4,<9'
     redaxo: ^5.16              # REDAXO Core-Version
     packages:                  # Plugins und Addons
         yform: "^4"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Die Mindestanforderung für die PHP-Version wurde auf >=8.4 aktualisiert.
  - Nicht verwendete Importe und überflüssige Leerzeilen wurden entfernt.
  - Die Code-Formatierung und Einrückung wurden zur besseren Lesbarkeit vereinheitlicht.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->